### PR TITLE
Adding new switch -ClearSheet

### DIFF
--- a/PSExcel/Export-XLSX.ps1
+++ b/PSExcel/Export-XLSX.ps1
@@ -57,9 +57,9 @@
 		
 		$Worksheet = 'Files'
 
-        Export-XLSX -Path C:\Files.xlsx -InputObject $Files -WorksheetName $Worksheet -ClearSheet
+        Export-XLSX -Path C:\temp\Files.xlsx -InputObject $Files -WorksheetName $Worksheet -ClearSheet
 
-        Export file listing to C:\Files.xlsx to the worksheet named "Files".  If it exists already, clear the sheet then import the data.
+        Export file listing to C:\temp\Files.xlsx to the worksheet named "Files".  If it exists already, clear the sheet then import the data.
 
     .EXAMPLE
 
@@ -264,7 +264,7 @@
             {
                 $Excel = New-Object OfficeOpenXml.ExcelPackage($Path)
                 $Workbook = $Excel.Workbook
-                if ($ClearSheet)
+                if ($ClearSheet -and (Test-Path $Path) )
 					{
 						$WorkSheet=$Excel.Workbook.Worksheets | Where-Object {$_.Name -like $WorkSheetName}
 						$WorkSheet.Cells[$WorkSheet.Dimension.Start.Row, $WorkSheet.Dimension.Start.Column, $WorkSheet.Dimension.End.Row, $WorkSheet.Dimension.End.Column].Clear();        


### PR DESCRIPTION
This switch gives you the ability to import into an existing worksheet in an existing workbook without overwriting the entire file.  In my situation I use it for populating/updating data into excel files that have already been setup with Pivot Tables, Charts, ect and just need the data source updated.