### PR TITLE
Added PivotFunction parameter

### DIFF
--- a/PSExcel/Add-PivotTable.ps1
+++ b/PSExcel/Add-PivotTable.ps1
@@ -163,7 +163,7 @@
         [string[]]$PivotRows,
         [string[]]$PivotColumns,
         [string[]]$PivotValues,
-        [OfficeOpenXml.Table.PivotTable.DataFieldFunctions]$PivotFunction = [OpenOfficeXml.Table.PivotTable.DataFieldFunction]::Count,
+        [OfficeOpenXml.Table.PivotTable.DataFieldFunctions]$PivotFunction = [OfficeOpenXml.Table.PivotTable.DataFieldFunctions]::Count,
 
         [OfficeOpenXml.Drawing.Chart.eChartType]$ChartType,
         [string]$ChartTitle,

--- a/PSExcel/Add-PivotTable.ps1
+++ b/PSExcel/Add-PivotTable.ps1
@@ -48,6 +48,9 @@
     .PARAMETER PivotColumns
         Pivot on these columns
 
+    .PARAMETER PivotFunction
+        If specified, use this summary mode for pivot values (defaults to Count mode)
+
     .PARAMETER ChartType
         If specified, add a chart with this type
 
@@ -160,6 +163,7 @@
         [string[]]$PivotRows,
         [string[]]$PivotColumns,
         [string[]]$PivotValues,
+        [OfficeOpenXml.Table.PivotTable.DataFieldFunctions]$PivotFunction = [OpenOfficeXml.Table.PivotTable.DataFieldFunction]::Count,
 
         [OfficeOpenXml.Drawing.Chart.eChartType]$ChartType,
         [string]$ChartTitle,
@@ -278,7 +282,8 @@
 
                     foreach ($Value in @($PivotValues | Select -Unique))
                     {
-                        [void]$PivotTable.DataFields.Add($PivotTable.Fields[$Value])
+                        $field = $PivotTable.DataFields.Add($PivotTable.Fields[$Value])
+                        $field.Function = $PivotFunction
                     }
                 }
 

--- a/PSExcel/Export-XLSX.ps1
+++ b/PSExcel/Export-XLSX.ps1
@@ -30,6 +30,9 @@
     .PARAMETER PivotValues
         If specified, add pivot table pivoting on these values
 
+    .PARAMETER PivotFunction
+        If specified, use this summary mode for pivot values (defaults to Count mode)
+
     .PARAMETER ChartType
         If specified, add pivot chart of this type
 
@@ -208,6 +211,8 @@
         [string[]]$PivotColumns,
 
         [string[]]$PivotValues,
+        
+        [OfficeOpenXml.Table.PivotTable.DataFieldFunctions]$PivotFunction = [OpenOfficeXml.Table.PivotTable.DataFieldFunction]::Count,
 
         [OfficeOpenXml.Drawing.Chart.eChartType]$ChartType,
 
@@ -446,10 +451,11 @@
             if($PSBoundParameters.Keys -match 'Pivot')
             {
                 $Params = @{}
-                if($PivotRows)    {$Params.Add('PivotRows',$PivotRows)}
-                if($PivotColumns) {$Params.Add('PivotColumns',$PivotColumns)}
-                if($PivotValues)  {$Params.Add('PivotValues',$PivotValues)}
-                if($ChartType)    {$Params.Add('ChartType',$ChartType)}
+                if($PivotRows)     {$Params.Add('PivotRows',$PivotRows)}
+                if($PivotColumns)  {$Params.Add('PivotColumns',$PivotColumns)}
+                if($PivotValues)   {$Params.Add('PivotValues',$PivotValues)}
+                if($PivotFunction) {$Params.Add('PivotFunction',$PivotFunction)}
+                if($ChartType)     {$Params.Add('ChartType',$ChartType)}
                 $Excel = Add-PivotTable @Params -Excel $Excel -WorkSheetName $WorksheetName -Passthru -ErrorAction stop
 
             }

--- a/PSExcel/Export-XLSX.ps1
+++ b/PSExcel/Export-XLSX.ps1
@@ -212,7 +212,7 @@
 
         [string[]]$PivotValues,
         
-        [OfficeOpenXml.Table.PivotTable.DataFieldFunctions]$PivotFunction = [OpenOfficeXml.Table.PivotTable.DataFieldFunction]::Count,
+        [OfficeOpenXml.Table.PivotTable.DataFieldFunctions]$PivotFunction = [OfficeOpenXml.Table.PivotTable.DataFieldFunctions]::Count,
 
         [OfficeOpenXml.Drawing.Chart.eChartType]$ChartType,
 


### PR DESCRIPTION
Added the ability to specify the summary function Excel uses to display
values in a PivotTable.

Previously, the summary function was not specified, and Excel
interpreted it as Sum by default. The Sum function is not terribly
useful when dealing with String data.

Note that this changes default behavior by specifying the default
function as Count.

Addresses #26.