### PR TITLE
Validate WorksheetName's length

### DIFF
--- a/PSExcel/Export-XLSX.ps1
+++ b/PSExcel/Export-XLSX.ps1
@@ -207,6 +207,7 @@
 
         [string[]]$Header,
 
+	[ValidateLength(1,31)]
         [string]$WorksheetName = "Worksheet1",
 
         [string[]]$PivotRows,


### PR DESCRIPTION
Fixes #62 by validating the max length of `$WorksheetName`
to be lower than or equals to 31