### PR TITLE
Update Import-XLSX.ps1

### DIFF
--- a/PSExcel/Import-XLSX.ps1
+++ b/PSExcel/Import-XLSX.ps1
@@ -128,6 +128,12 @@
                 else
                 {
                     $worksheet = $workbook.Worksheets[$Sheet]
+                    if(!$worksheet)
+                    {
+                        Write-Error "Unkown worksheet and/or Failed to gather Worksheet '$Sheet' data for file '$file':`n$_"
+                        continue
+                    }
+                    
                     $dimension = $worksheet.Dimension
 
                     $Rows = $dimension.Rows


### PR DESCRIPTION
Throw exception when worksheet is empty/not found due to wrong worksheet name or because worksheet was renamed.