### PR TITLE
Fix for column headers that are not strings

### DIFF
--- a/PSExcel/Import-XLSX.ps1
+++ b/PSExcel/Import-XLSX.ps1
@@ -165,7 +165,7 @@
                         $PotentialHeader = $worksheet.Cells.Item($RowStart,$Column).Value
                     }
 
-                    if( -Not $PotentialHeader -Or $PotentialHeader.Trim().Equals("") )
+                    if( -Not $PotentialHeader -Or $PotentialHeader.ToString().Trim().Equals("") )
                     {
                         Write-Warning "Header in column $Column is whitespace or empty, setting header to '<Column $Column>'"
                         $PotentialHeader = "<Column $Column>" # Use placeholder name


### PR DESCRIPTION
Currently, the call to `Trim` is failing because column headers might be numbers or dates, which have no `Trim` method. Since any object has a `ToString` method, this should fix it.