### PR TITLE
Path to DLL is case sensitive in Linux

### DIFF
--- a/PSExcel/PSExcel.psm1
+++ b/PSExcel/PSExcel.psm1
@@ -5,7 +5,7 @@
     }
 
 #Import assembly:
-    $BinaryPath = Join-Path $PSScriptRoot 'lib\epplus.dll'
+    $BinaryPath = Join-Path $PSScriptRoot 'lib\EPPlus.dll'
     if( -not ($Library = Add-Type -path $BinaryPath -PassThru -ErrorAction stop) )
     {
         Throw "Failed to load EPPlus binary from $BinaryPath"


### PR DESCRIPTION
EPPlus.dll didnt work in Linux because the path is case sensitiv